### PR TITLE
fix: local M

### DIFF
--- a/lua/neorg/modules/external/templates/snippet_handler.lua
+++ b/lua/neorg/modules/external/templates/snippet_handler.lua
@@ -10,7 +10,7 @@ local rep = require("luasnip.extras").rep
 -- stylua: ignore end
 ---@diagnostic enable
 
-M = {
+local M = {
     keywords = {}, -- will be updated with M.add_keywords
     magic_keywords = {},
 }


### PR DESCRIPTION
There was a global `M` in here that can get overridden by other people (probably also accidentally) using a global `M`.

This is the best type of bug&mdash;the one line fix bug.
